### PR TITLE
Pass me wrap with dynamic Member Lookup

### DIFF
--- a/Sources/Core/Me.swift
+++ b/Sources/Core/Me.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Foundation
 
 public struct Me: Identifiable, Equatable {
-    public let id: ID
+    public var id: ID
 
     public struct ID: RawRepresentable, Equatable, Hashable {
         public let rawValue: String
@@ -12,12 +12,29 @@ public struct Me: Identifiable, Equatable {
     }
 }
 
+@dynamicMemberLookup
+public struct MeMembers {
+    public let me: Me!
+    
+    public init(me: Me) {
+        self.me = me
+    }
+
+    internal init() {
+        me = nil
+    }
+
+    public subscript<U>(dynamicMember keyPath: KeyPath<Me, U>) -> U {
+        return me![keyPath: keyPath]
+    }
+}
+
 public struct MeEnvironmentKey: EnvironmentKey {
-    public static var defaultValue: Me?
+    public static var defaultValue: MeMembers = .init()
 }
 
 public extension EnvironmentValues {
-    var me: Me! {
+    var me: MeMembers {
         get {
             self[MeEnvironmentKey.self]
         }

--- a/Sources/Domain/SpotPost/Components/SpotPostSubmitButton.swift
+++ b/Sources/Domain/SpotPost/Components/SpotPostSubmitButton.swift
@@ -3,7 +3,8 @@ import SwiftUI
 import CoreLocation
 
 public struct SpotPostSubmitButton: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.me) var me
+    @Environment(\.dismiss) var dismiss
 
     @StateObject var upload = Upload()
     @StateObject var mutation = Mutation<SpotAddMutation>()
@@ -33,13 +34,16 @@ public struct SpotPostSubmitButton: View {
     }
 
     private func save() {
+        if submitButtonIsDisabled {
+            return
+        }
         guard let photoLibraryResult = photoLibraryResult, let placemark = placemark else {
             return
         }
         Task {
             do {
             // TODO: fill values
-                let uploaded = try await upload(path: .spot(userID: "", spotID: ""), image: photoLibraryResult.image)
+                let uploaded = try await upload(path: .spot(userID: me.id), image: photoLibraryResult.image)
                 try await mutation(
                     for: .init(
                         spotAddInput: .init(

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -19,7 +19,7 @@ struct RootView: View {
                 RequireLocationAuthorizationView()
             case let .main(me):
                 SpotMapView()
-                    .environment(\.me, me)
+                    .environment(\.me, .init(me: me))
             }
         }
         .task {

--- a/Sources/Service/CloudStorage/CloudStorage.swift
+++ b/Sources/Service/CloudStorage/CloudStorage.swift
@@ -13,12 +13,12 @@ public struct CloudStorage {
 // MARK: - asinc/await
 extension CloudStorage {
     public enum PathKind {
-        case spot(userID: String, spotID: String)
+        case spot(userID: Me.ID)
 
         var path: String {
             switch self {
-            case let .spot(userID, spotID):
-                return "users/\(userID)/spots/\(spotID)"
+            case let .spot(userID):
+                return "users/\(userID.rawValue)/spots"
             }
         }
     }


### PR DESCRIPTION
## Abstract
Me の Envrionment経由での渡し方を変更。MeをラップしたMeMembersを渡していく

## Why
Meは認証が終わるまではOptionalな状態なので、EnvrionmentKey.defaultValueにはMe?の型宣言をしなければならない。EnvironmentValues.meのアクセスもMe?になってしまい、本来であれば不要なキャストが発生したので一つ間に挟むことにした。MeMembersは常に非Optionalで中身はme: Me!型を持っている。そしてKeyPath dynamic member lookup の機能を用いてMeの機能にフルアクセスするようにした