### PR TITLE
Add border to spot map image

### DIFF
--- a/Sources/Domain/Spot/Components/SpotMapImage.swift
+++ b/Sources/Domain/Spot/Components/SpotMapImage.swift
@@ -14,5 +14,6 @@ struct SpotMapImage: View {
         }
         .frame(width: 40, height: 40)
         .clipShape(Circle())
+        .overlay(Circle().stroke(GradientColor.barn, lineWidth: 1))
     }
 }

--- a/Sources/Domain/Spot/SpotMapView.swift
+++ b/Sources/Domain/Spot/SpotMapView.swift
@@ -37,7 +37,7 @@ struct SpotMapView: View {
                 } label: {
                     Image("addSpot")
                         .frame(width: 64, height: 64, alignment: .center)
-                        .background(GradientColor.lower)
+                        .background(GradientColor.barn)
                         .clipShape(Circle())
                 }
             }


### PR DESCRIPTION
## Abstract
SpotMapImageにborderをつけた
画像が増えると境界線が曖昧だった