### PR TITLE
Implement fetch next if possible

### DIFF
--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -12,7 +12,7 @@ struct SpotMapView: View {
     @State var spots: [SpotsQuery.Data.Spot] = []
     @State var error: Error?
     @State var region: MKCoordinateRegion?
-    @State var isPresentingSpotPost = false;
+    @State var isPresentingSpotPost = false
 
     var body: some View {
         ZStack(alignment: .init(horizontal: .center, vertical: .bottom)) {

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -127,3 +127,32 @@ extension SpotsQuery {
         )
     }
 }
+
+fileprivate struct SpotRange {
+    var minLatitude: Latitude
+    var minLongitude: Longitude
+    var maxLatitude: Latitude
+    var maxLongitude: Longitude
+}
+fileprivate extension Array where Element == SpotsQuery.Data.Spot {
+    func spotRange() -> SpotRange? {
+        guard let first = first else {
+            return nil
+        }
+        let spotRange = SpotRange(minLatitude: first.geoPoint.latitude, minLongitude: first.geoPoint.longitude, maxLatitude: first.geoPoint.latitude, maxLongitude: first.geoPoint.longitude)
+        return reduce(into: spotRange) { partialResult, spot in
+            if partialResult.minLatitude > spot.geoPoint.latitude {
+                partialResult.minLatitude = spot.geoPoint.latitude
+            }
+            if partialResult.maxLatitude < spot.geoPoint.latitude {
+                partialResult.maxLatitude = spot.geoPoint.latitude
+            }
+            if partialResult.minLongitude > spot.geoPoint.longitude {
+                partialResult.minLongitude = spot.geoPoint.longitude
+            }
+            if partialResult.maxLongitude < spot.geoPoint.longitude {
+                partialResult.maxLongitude = spot.geoPoint.longitude
+            }
+        }
+    }
+}

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -24,7 +24,7 @@ struct SpotMapView: View {
                     SpotMapImage(fragment: spot.fragments.spotMapImageFragment)
                 }
             }).onChange(of: mapCoordinateRegion.wrappedValue) { newRegion in
-                print("newRegion: ", newRegion)
+                fetchIfNeeded(region: newRegion)
             }
 
             HStack(alignment: .bottom) {
@@ -84,18 +84,16 @@ struct SpotMapView: View {
         })
     }
 
-    private func fetchIfNeeded() {
-        guard let region = region else {
-            return
-        }
+    private func fetchIfNeeded(region: MKCoordinateRegion) {
         if query.isFetching {
             return
         }
+
         if spots.contains(where: { spot in
-            region.minLatitude < spot.geoPoint.latitude &&
-            region.maxLatitude > spot.geoPoint.latitude &&
-            region.minLongitude < spot.geoPoint.longitude &&
-            region.maxLongitude > spot.geoPoint.longitude
+            region.minLatitude <= spot.geoPoint.latitude &&
+            region.maxLatitude >= spot.geoPoint.latitude &&
+            region.minLongitude <= spot.geoPoint.longitude &&
+            region.maxLongitude >= spot.geoPoint.longitude
         }) {
             Task {
                 if let response = try? await query(for: .init(region: region)) {

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -88,7 +88,7 @@ struct SpotMapView: View {
         if query.isFetching {
             return
         }
-        if spots.isInRange(region: region) {
+        if spots.isOutOfRange(region: region) {
             Task {
                 if let response = try? await query(for: .init(region: region)) {
                     spots += response.spots
@@ -150,15 +150,14 @@ fileprivate extension Array where Element == SpotsQuery.Data.Spot {
         }
     }
 
-    func isInRange(region: MKCoordinateRegion) -> Bool {
+    func isOutOfRange(region: MKCoordinateRegion) -> Bool {
         guard let spotRange = spotRange() else {
             return false
         }
 
-        let isOutOfRange = region.center.latitude < spotRange.minLatitude ||
+        return region.center.latitude < spotRange.minLatitude ||
             region.center.latitude > spotRange.maxLatitude ||
             region.center.longitude < spotRange.minLongitude ||
             region.center.longitude > spotRange.maxLongitude
-        return !isOutOfRange
     }
 }

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -155,4 +155,16 @@ fileprivate extension Array where Element == SpotsQuery.Data.Spot {
             }
         }
     }
+
+    func isInRange(region: MKCoordinateRegion) -> Bool {
+        guard let spotRange = spotRange() else {
+            return false
+        }
+
+        let isOutOfRange = region.center.latitude < spotRange.minLatitude ||
+            region.center.latitude > spotRange.maxLatitude ||
+            region.center.longitude < spotRange.minLongitude ||
+            region.center.longitude > spotRange.maxLongitude
+        return !isOutOfRange
+    }
 }

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -88,13 +88,7 @@ struct SpotMapView: View {
         if query.isFetching {
             return
         }
-
-        if spots.contains(where: { spot in
-            region.minLatitude <= spot.geoPoint.latitude &&
-            region.maxLatitude >= spot.geoPoint.latitude &&
-            region.minLongitude <= spot.geoPoint.longitude &&
-            region.maxLongitude >= spot.geoPoint.longitude
-        }) {
+        if spots.isInRange(region: region) {
             Task {
                 if let response = try? await query(for: .init(region: region)) {
                     spots += response.spots

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -88,6 +88,7 @@ struct SpotMapView: View {
         if query.isFetching {
             return
         }
+        // NOTE: これだと新しいSpotを取得できなかった場合に何度も呼ばれてしまう
         if spots.isOutOfRange(region: region) {
             Task {
                 if let response = try? await query(for: .init(region: region)) {

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -9,7 +9,7 @@ struct SpotMapView: View {
     @StateObject var cache = Cache<SpotsQuery>()
     @StateObject var query = Query<SpotsQuery>()
 
-    @State var response: SpotsQuery.Data?
+    @State var spots: [SpotsQuery.Data.Spot] = []
     @State var error: Error?
     @State var region: MKCoordinateRegion?
     @State var isPresentingSpotPost = false;
@@ -46,7 +46,7 @@ struct SpotMapView: View {
             onDismiss: {
                 Task {
                     if let response = try? await query(for: .init(region: mapCoordinateRegion.wrappedValue)) {
-                        self.response = response
+                        self.spots += response.spots
                     }
                 }
             },
@@ -61,16 +61,12 @@ struct SpotMapView: View {
                 let userLocation = try await locationManager.userLocation()
                 region = .init(center: userLocation.coordinate, span: mapCoordinateRegion.wrappedValue.span)
 
-                response = await cache(for: .init(region: mapCoordinateRegion.wrappedValue))
-                response = try await query(for: .init(region: mapCoordinateRegion.wrappedValue))
+                spots = await cache(for: .init(region: mapCoordinateRegion.wrappedValue))?.spots ?? []
+                spots += try await query(for: .init(region: mapCoordinateRegion.wrappedValue)).spots
             } catch {
                 self.error = error
             }
         }
-    }
-
-    var spots: [SpotsQuery.Data.Spot] {
-        response?.spots ?? []
     }
 
     // Workaround of SwiftUI.Map unavoidable warning

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -84,6 +84,26 @@ struct SpotMapView: View {
         })
     }
 
+    private func fetchIfNeeded() {
+        guard let region = region else {
+            return
+        }
+        if query.isFetching {
+            return
+        }
+        if spots.contains(where: { spot in
+            region.minLatitude < spot.geoPoint.latitude &&
+            region.maxLatitude > spot.geoPoint.latitude &&
+            region.minLongitude < spot.geoPoint.longitude &&
+            region.maxLongitude > spot.geoPoint.longitude
+        }) {
+            Task {
+                if let response = try? await query(for: .init(region: region)) {
+                    spots += response.spots
+                }
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Abstract
画面の操作で現在の位置情報を変えた場合にfetchし直す処理を追加

## How
方法として現在のspot一覧を取得して、そこから(min|max) x (latitude|longitude) な値を切り出して、それと現在地の値と比較してpostするというもの

と思ったが、この場合はAPIのリクエストでspotが無い場合に何度もリクエストを送ることになるのでボツ

マージ後にViewModelを作り、現在リクエスト済みのMapの範囲を計算するように書き直す