### PR TITLE
画像読み込みが複数呼ばれてしまうのをどうにかする

### DIFF
--- a/Posusume.xcodeproj/project.pbxproj
+++ b/Posusume.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		2067175D26B5A32F00C85A25 /* Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2067175C26B5A32F00C85A25 /* Scalar.swift */; };
 		2067175F26B641F100C85A25 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2067175E26B641F100C85A25 /* APIClient.swift */; };
 		208F8AED272907B300D604DA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 208F8AEC272907B300D604DA /* GoogleService-Info.plist */; };
+		208FE939277F839B00C43DC1 /* CachedAsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208FE938277F839B00C43DC1 /* CachedAsyncImageView.swift */; };
 		20A088732708FA1B00D94272 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A088722708FA1B00D94272 /* Cache.swift */; };
 		20A088752708FDED00D94272 /* Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A088742708FDED00D94272 /* Mutation.swift */; };
 		20A09D1B2701F2640090E22F /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A09D1A2701F2640090E22F /* Query.swift */; };
@@ -144,6 +145,7 @@
 		2067175C26B5A32F00C85A25 /* Scalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scalar.swift; sourceTree = "<group>"; };
 		2067175E26B641F100C85A25 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		208F8AEC272907B300D604DA /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		208FE938277F839B00C43DC1 /* CachedAsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImageView.swift; sourceTree = "<group>"; };
 		20A088722708FA1B00D94272 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		20A088742708FDED00D94272 /* Mutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mutation.swift; sourceTree = "<group>"; };
 		20A09D1A2701F2640090E22F /* Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 		2005EE4226FA0A41009001C7 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				208FE937277F838E00C43DC1 /* View */,
 				201F268B27009C7B00A5DD1E /* Secret.swift */,
 				2005EE5026FA825A009001C7 /* Error */,
 				BA249E742625E217000DA60F /* Me.swift */,
@@ -314,6 +317,14 @@
 				2067175C26B5A32F00C85A25 /* Scalar.swift */,
 			);
 			path = Scalar;
+			sourceTree = "<group>";
+		};
+		208FE937277F838E00C43DC1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				208FE938277F839B00C43DC1 /* CachedAsyncImageView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		20A09D192701F25B0090E22F /* ObservableObject */ = {
@@ -849,6 +860,7 @@
 				2016C8BE272202BC00B438C6 /* TextFieldComponent.swift in Sources */,
 				20A96B9E271B965A00E1765B /* SpotDetailImage.swift in Sources */,
 				20A088732708FA1B00D94272 /* Cache.swift in Sources */,
+				208FE939277F839B00C43DC1 /* CachedAsyncImageView.swift in Sources */,
 				BA26C8522621939A006555AE /* CloudStorage.swift in Sources */,
 				20A09D1B2701F2640090E22F /* Query.swift in Sources */,
 				BAFF7024261C3FB300584593 /* Color.swift in Sources */,

--- a/Sources/Core/View/CachedAsyncImageView.swift
+++ b/Sources/Core/View/CachedAsyncImageView.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftUI
+
+public struct NetworkAsyncImageView<Content: View>: View {
+    @State var phase: SwiftUI.AsyncImagePhase = .empty
+
+    let url: URL?
+    let urlSession: URLSession
+    let scale: CGFloat
+    let transaction: Transaction
+    let content: (SwiftUI.AsyncImagePhase) -> Content
+
+    public init(url: URL?, urlCache: URLCache = .shared, cachePolicty: NSURLRequest.CachePolicy = .returnCacheDataElseLoad, scale: CGFloat = 1, transaction: Transaction = Transaction(), @ViewBuilder content: @escaping (SwiftUI.AsyncImagePhase) -> Content) {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = urlCache
+        configuration.requestCachePolicy = cachePolicty
+
+        self.url = url
+        self.urlSession = .init(configuration: configuration)
+        self.scale = scale
+        self.transaction = transaction
+        self.content = content
+    }
+
+    public init<I: View, P: View>(url: Foundation.URL?, urlCache: URLCache = .shared, cachePolicty: NSURLRequest.CachePolicy = .returnCacheDataElseLoad, scale: CoreGraphics.CGFloat = 1, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == _ConditionalContent<I, P> {
+        self.init(url: url, urlCache: urlCache, cachePolicty: cachePolicty, scale: scale) { phase in
+            if let image = phase.image {
+                content(image)
+            } else {
+                placeholder()
+            }
+        }
+    }
+
+    public var body: some View {
+        content(phase)
+            .animation(transaction.animation, value: phase.image)
+            .task(id: url) {
+                await load(url: url)
+            }
+    }
+
+    struct NetworkError: Error {
+
+    }
+
+    private func load(url: URL?) async {
+        guard let url = url else {
+            phase = .empty
+            return
+        }
+
+        do {
+            let request = URLRequest(url: url)
+            let (data, _) = try await urlSession.data(for: request)
+            if let uiImage = UIImage(data: data) {
+                let image = Image(uiImage: uiImage)
+                phase = .success(image)
+            } else {
+                throw NetworkError()
+            }
+        } catch {
+            phase = .failure(error)
+        }
+    }
+}
+

--- a/Sources/Core/View/CachedAsyncImageView.swift
+++ b/Sources/Core/View/CachedAsyncImageView.swift
@@ -88,3 +88,5 @@ public struct CachedAsyncImageView<Content: View>: View {
     }
 }
 
+
+public typealias AsyncImageView = CachedAsyncImageView

--- a/Sources/Core/View/CachedAsyncImageView.swift
+++ b/Sources/Core/View/CachedAsyncImageView.swift
@@ -1,6 +1,17 @@
 import Foundation
 import SwiftUI
 
+// For example, SwiftUI.Map recreates AsyncImage every time it zooms. Therefore, instead of having a URLSession in the View, we'll make it common and make it easier to cache.
+private var urlSession: URLSession = {
+    // URLCache.shared memoryCapacity 4MB, diskCapacity: 20MB in document. But actually memoryCapacity 512KB, diskCapacity: 10MB
+    // Posusume loads a lot of images, so it is increasing the capacity
+    let configuration = URLSessionConfiguration.default
+    configuration.urlCache = .init(memoryCapacity: 20 * 1024 * 1024, diskCapacity: 100 * 1024 * 1024, directory: nil)
+    configuration.requestCachePolicy = .returnCacheDataElseLoad
+
+    return .init(configuration: configuration)
+}()
+
 public struct CachedAsyncImageView<Content: View>: View {
     @State var phase: SwiftUI.AsyncImagePhase = .empty
 

--- a/Sources/Core/View/CachedAsyncImageView.swift
+++ b/Sources/Core/View/CachedAsyncImageView.swift
@@ -13,28 +13,41 @@ private var urlSession: URLSession = {
 }()
 
 public struct CachedAsyncImageView<Content: View>: View {
-    @State var phase: SwiftUI.AsyncImagePhase = .empty
+    @State var phase: SwiftUI.AsyncImagePhase
 
     let url: URL?
-    let urlSession: URLSession
     let scale: CGFloat
     let transaction: Transaction
     let content: (SwiftUI.AsyncImagePhase) -> Content
 
-    public init(url: URL?, urlCache: URLCache = .shared, cachePolicty: NSURLRequest.CachePolicy = .returnCacheDataElseLoad, scale: CGFloat = 1, transaction: Transaction = Transaction(), @ViewBuilder content: @escaping (SwiftUI.AsyncImagePhase) -> Content) {
-        let configuration = URLSessionConfiguration.default
-        configuration.urlCache = urlCache
-        configuration.requestCachePolicy = cachePolicty
+    // Use on network request or cache key
+    static func request(url: URL) -> URLRequest {
+        .init(url: url)
+    }
 
+    public init(url: URL?, scale: CGFloat = 1, transaction: Transaction = Transaction(), @ViewBuilder content: @escaping (SwiftUI.AsyncImagePhase) -> Content) {
         self.url = url
-        self.urlSession = .init(configuration: configuration)
         self.scale = scale
         self.transaction = transaction
         self.content = content
+
+        let phase: SwiftUI.AsyncImagePhase = {
+            guard let url = url else {
+                return .empty
+            }
+
+            if let cachedResponse = urlSession.configuration.urlCache?.cachedResponse(for: Self.request(url: url)) {
+                if let uiImage = UIImage(data: cachedResponse.data) {
+                    return .success(Image(uiImage: uiImage))
+                }
+            }
+            return .empty
+        }()
+        self._phase = .init(initialValue: phase)
     }
 
-    public init<I: View, P: View>(url: Foundation.URL?, urlCache: URLCache = .shared, cachePolicty: NSURLRequest.CachePolicy = .returnCacheDataElseLoad, scale: CoreGraphics.CGFloat = 1, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == _ConditionalContent<I, P> {
-        self.init(url: url, urlCache: urlCache, cachePolicty: cachePolicty, scale: scale) { phase in
+    public init<I: View, P: View>(url: Foundation.URL?, scale: CoreGraphics.CGFloat = 1, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == _ConditionalContent<I, P> {
+        self.init(url: url, scale: scale) { phase in
             if let image = phase.image {
                 content(image)
             } else {
@@ -61,12 +74,11 @@ public struct CachedAsyncImageView<Content: View>: View {
             return
         }
 
+        let request = Self.request(url: url)
         do {
-            let request = URLRequest(url: url)
             let (data, _) = try await urlSession.data(for: request)
             if let uiImage = UIImage(data: data) {
-                let image = Image(uiImage: uiImage)
-                phase = .success(image)
+                phase = .success(Image(uiImage: uiImage))
             } else {
                 throw NetworkError()
             }

--- a/Sources/Core/View/CachedAsyncImageView.swift
+++ b/Sources/Core/View/CachedAsyncImageView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-public struct NetworkAsyncImageView<Content: View>: View {
+public struct CachedAsyncImageView<Content: View>: View {
     @State var phase: SwiftUI.AsyncImagePhase = .empty
 
     let url: URL?

--- a/Sources/Features/SpotDetail/Components/SpotDetailImage.swift
+++ b/Sources/Features/SpotDetail/Components/SpotDetailImage.swift
@@ -6,7 +6,7 @@ struct SpotDetailImage: View {
     let fragment: SpotDetailImageFragment
 
     var body: some View {
-        CachedAsyncImageView(url: fragment.imageUrl) { image in
+        AsyncImageView(url: fragment.imageUrl) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/Sources/Features/SpotDetail/Components/SpotDetailImage.swift
+++ b/Sources/Features/SpotDetail/Components/SpotDetailImage.swift
@@ -6,7 +6,7 @@ struct SpotDetailImage: View {
     let fragment: SpotDetailImageFragment
 
     var body: some View {
-        AsyncImage(url: fragment.imageUrl) { image in
+        CachedAsyncImageView(url: fragment.imageUrl) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/Sources/Features/SpotMap/Components/SpotMapImage.swift
+++ b/Sources/Features/SpotMap/Components/SpotMapImage.swift
@@ -32,12 +32,3 @@ struct SpotMapImage: View {
         fragment.resizedSpotImageUrLs.thumbnail ?? fragment.imageUrl
     }
 }
-
-
-extension SpotMapImage: Equatable {
-    static func ==(lhs: SpotMapImage, rhs: SpotMapImage) -> Bool {
-        lhs.imageURL == rhs.imageURL
-    }
-}
-
-extension SpotMapImageFragment: Identifiable { }

--- a/Sources/Features/SpotMap/Components/SpotMapImage.swift
+++ b/Sources/Features/SpotMap/Components/SpotMapImage.swift
@@ -9,7 +9,6 @@ struct SpotMapImage: View {
     @State var isPresentingSpotDetail: Bool = false
 
     var body: some View {
-        let _ = Self._printChanges()
         AsyncImageView(url: imageURL) { image in
             image
                 .resizable()

--- a/Sources/Features/SpotMap/Components/SpotMapImage.swift
+++ b/Sources/Features/SpotMap/Components/SpotMapImage.swift
@@ -10,7 +10,7 @@ struct SpotMapImage: View {
 
     var body: some View {
         let _ = Self._printChanges()
-        AsyncImage(url: imageURL) { image in
+        CachedAsyncImageView(url: imageURL) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/Sources/Features/SpotMap/Components/SpotMapImage.swift
+++ b/Sources/Features/SpotMap/Components/SpotMapImage.swift
@@ -10,7 +10,7 @@ struct SpotMapImage: View {
 
     var body: some View {
         let _ = Self._printChanges()
-        CachedAsyncImageView(url: imageURL) { image in
+        AsyncImageView(url: imageURL) { image in
             image
                 .resizable()
                 .scaledToFill()

--- a/Sources/Features/SpotMap/Components/SpotMapImage.swift
+++ b/Sources/Features/SpotMap/Components/SpotMapImage.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import Apollo
+import MapKit
 
 struct SpotMapImage: View {
     let fragment: SpotMapImageFragment
@@ -8,6 +9,7 @@ struct SpotMapImage: View {
     @State var isPresentingSpotDetail: Bool = false
 
     var body: some View {
+        let _ = Self._printChanges()
         AsyncImage(url: imageURL) { image in
             image
                 .resizable()
@@ -26,7 +28,16 @@ struct SpotMapImage: View {
         .frame(width: 40, height: 40)
     }
 
-    private var imageURL: URL {
+    fileprivate var imageURL: URL {
         fragment.resizedSpotImageUrLs.thumbnail ?? fragment.imageUrl
     }
 }
+
+
+extension SpotMapImage: Equatable {
+    static func ==(lhs: SpotMapImage, rhs: SpotMapImage) -> Bool {
+        lhs.imageURL == rhs.imageURL
+    }
+}
+
+extension SpotMapImageFragment: Identifiable { }

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -19,6 +19,7 @@ struct SpotMapView: View {
                 annotationContent: { spot in
                 MapAnnotation(coordinate: spot.coordinate) {
                     SpotMapImage(fragment: spot.fragments.spotMapImageFragment)
+                        .equatable()
                 }
             }).onChange(of: mapCoordinateRegion.wrappedValue) { newRegion in
                 viewModel.fetch(region: newRegion)

--- a/Sources/Features/SpotMap/SpotMapView.swift
+++ b/Sources/Features/SpotMap/SpotMapView.swift
@@ -19,7 +19,6 @@ struct SpotMapView: View {
                 annotationContent: { spot in
                 MapAnnotation(coordinate: spot.coordinate) {
                     SpotMapImage(fragment: spot.fragments.spotMapImageFragment)
-                        .equatable()
                 }
             }).onChange(of: mapCoordinateRegion.wrappedValue) { newRegion in
                 viewModel.fetch(region: newRegion)


### PR DESCRIPTION
## Reason
主にSwiftUI.Map上に表示するAnnotationがAsyncImageを含んでいる時に困っている。例えばZoom In/Out すると Annotation に含まれているViewが毎回作り直されてしまう。さらにそのViewがAsyncImageを持っている場合、作り直しのたびにAsyncImageも作り直されるので画像取得のリクエストが毎回走ってしまう

## How
AsyncImageの画像取得において、1度取ってきた画像をキャッシュする。キャッシュした画像を使い回す。処理を用意したくて `CachedAsyncImageView` を用意した。さらにURLSessionを`CachedAsyncImageView` 全体で共通化することにより、Viewの再生成に関わらずにキャッシュヒットされるようにした

またPosusumeでは画像取得も多くなるのでURLCacheのCapacityも増やすことにした